### PR TITLE
 Severe performance improvement in onlyheat calculations of strainMap

### DIFF
--- a/classes/phonon.m
+++ b/classes/phonon.m
@@ -183,7 +183,10 @@ classdef phonon < simulation
                     % current temperature for each subsystem                        
                     % traverse subsystems
                     for j=1:K
-                        intAlphaT(:,j) = cellfun(@feval,intLinThermExps(:,j),num2cell(squeeze(tempMap(i,:,j))'));
+                        % traverse unit cells
+                        for n=1:N
+                            intAlphaT(n,j) = intLinThermExps{n,j}(tempMap(i,n,j));      % cellfun(@feval,intLinThermExps(:,j),num2cell(squeeze(tempMap(i,:,j))'));
+                        end
                     end%for
 
                     % calculate the length of the sticks of each subsystem and sum


### PR DESCRIPTION
Similar to calcEnergyMap(), it is much more efficient not to vectorize the calculation of the sticks in a onlyheat calculation (no coherent strain response, only adiabatic strain response to stress). The usage of @feval seems to slow down the calculation severely. A test calculation is 7 times faster when using an explicit for-loop for traversing the individual unit cells.